### PR TITLE
Add runtime smoke test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,9 @@ test:
     - jxlpy
   commands:
     - pip check
+    - python run_test.py
+  files:
+    - run_test.py
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,12 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/jxlpy-{{ version }}.tar.gz
   sha256: 2aa766f1bde180ed10df313af2b48833825deeea631be490cb04ac786c021542
   patches:
+    - remove-cython-runtime.patch
     - support-windows.patch  # [win]
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 6
+  number: 7
 
 requirements:
   build:
@@ -29,7 +30,6 @@ requirements:
     - python
     - setuptools
   run:
-    - cython
     - libjxl
     - pillow
     - python

--- a/recipe/remove-cython-runtime.patch
+++ b/recipe/remove-cython-runtime.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 97702c5..0a7d7cb 100644
+--- a/setup.py
++++ b/setup.py
+@@ -29,7 +29,7 @@ setup(name='jxlpy',
+       },
+       include_package_data=True,
+-      install_requires=['cython'],
++      install_requires=[],
+       extras_require={'pillow': ['Pillow']},
+       python_requires='>=3.4',
+       ext_modules=cythonize([jxlpy_ext]),

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,34 @@
+from io import BytesIO
+
+from PIL import Image
+from jxlpy import JXLImagePlugin  # noqa: F401
+
+
+def main():
+    image = Image.new("RGB", (3, 2))
+    pixels = [
+        (0, 0, 0),
+        (255, 0, 0),
+        (0, 255, 0),
+        (0, 0, 255),
+        (255, 255, 255),
+        (7, 13, 29),
+    ]
+    image.putdata(pixels)
+
+    buffer = BytesIO()
+    image.save(buffer, format="JXL", lossless=True)
+    assert buffer.tell() > 0
+
+    buffer.seek(0)
+    decoded = Image.open(buffer)
+    decoded.load()
+
+    assert decoded.format == "JXL"
+    assert decoded.mode == "RGB"
+    assert decoded.size == image.size
+    assert decoded.tobytes() == image.tobytes()
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe/support-windows.patch
+++ b/recipe/support-windows.patch
@@ -30,7 +30,7 @@ index 97702c5..eeea3c7 100644
 -    extra_compile_args=['-O2'],
 -    extra_link_args=['-ljxl', '-ljxl_threads'],
 +    extra_compile_args=extra_compile_args,
-+    extra_link_args=extra_compile_args,
++    extra_link_args=extra_link_args,
 +    libraries=libraries,
      language='c++',
  )


### PR DESCRIPTION
## Summary
- add a recipe-local Pillow/JPEG XL lossless round-trip smoke test
- wire the test through package CI using `test.files` and `test.commands`
- patch upstream metadata so Cython remains build/host-only instead of a runtime requirement
- bump the build number to 7 for the runtime metadata change
- fix the existing Windows support patch to pass `extra_link_args` to the linker

## Validation
- `python -m py_compile recipe/run_test.py`
- `pixi exec -s python=3.12 -s jxlpy=0.9.5 -s pillow python recipe/run_test.py`
- `conda-smithy recipe-lint --conda-forge recipe`
- `git diff --check`
- PyPI sdist patch-apply check for `remove-cython-runtime.patch` and `support-windows.patch`